### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ A curated list of awesome Monero libraries, tools, and resources. More focused o
 - [Official GitHub](https://github.com/monero-project/monero)
 - [Official Twitter](https://twitter.com/monero)
 - [Official Reddit](https://www.reddit.com/r/Monero/)
-- [Unofficial Docs](https://docs.monero.study/)
+- [Unofficial Documentation](https://getmonero.dev/)
 - [Monero Guildes](https://moneroguides.org/)
 - [LocalMonero Knowledge Base](https://localmonero.co/nojs/knowledge)
 - [Monero Research Lab](https://github.com/monero-project/research-lab)
 - [MoneroResearch.info](https://moneroresearch.info/) - Hosts a collection of research papers relevant to improving Monero
 
-- [Implementing Seraphis](https://raw.githubusercontent.com/UkoeHB/Seraphis/master/implementing_seraphis/Impl-Seraphis-0-0-2.pdf)
+- [Implementing Seraphis](https://raw.githubusercontent.com/UkoeHB/Seraphis/master/implementing_seraphis/Impl-Seraphis-0-0-4.pdf) -  A working document on how Seraphis, a transaction protocol abstraction for p2p electronic cash systems, may be implemented.
 - [RandomX](https://github.com/tevador/RandomX) - RandomX is a proof-of-work (PoW) algorithm that is optimized for general-purpose CPUs.
 - [LMDB](https://github.com/LMDB/lmdb) - Lightning Memory-Mapped Database
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A curated list of awesome Monero libraries, tools, and resources. More focused o
 - [Official GitHub](https://github.com/monero-project/monero)
 - [Official Twitter](https://twitter.com/monero)
 - [Official Reddit](https://www.reddit.com/r/Monero/)
-- [Unofficial Documentation](https://getmonero.dev/)
+- [Monero Documentation](https://docs.getmonero.org/)
 - [Monero Guildes](https://moneroguides.org/)
 - [LocalMonero Knowledge Base](https://localmonero.co/nojs/knowledge)
 - [Monero Research Lab](https://github.com/monero-project/research-lab)


### PR DESCRIPTION
Updated link to the latest version of Implementing Seraphis book, 0.0.2 > 0.0.4, and added description 

Removed https://docs.monero.study from Unofficial Docs as it returns a SSL_ERROR_INTERNAL_ERROR_ALERT code. Replaced said link with Unofficial Documentation at https://getmonero.dev

I am unaware of any other mirrors for unofficial docs. Some prior comments here: https://github.com/monerodocs/md/issues/61