### PR TITLE
Add PikaSim to Merchants section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A curated list of awesome Monero libraries, tools, and resources. More focused o
 - [Monerica](https://github.com/monerica-project/monerica) ([Website](https://monerica.com/)) - A directory for a Monero circular economy
 - [Monero for Merchants](https://github.com/ASchmidt1024/monero-for-merchants-booklet) - A printable booklet to attract merchants to accept Monero (multiple languages!)
 - [XMRBazaar](https://xmrbazaar.com/) - P2P marketplace that accepts Monero. It is similar to MoneroMarket and Facebook Marketplace. Messenger for buyer/seller is included with PGP encryption. (still in beta)
+- [PikaSim](https://pikasim.com) - Privacy-focused eSIM provider for 170+ countries. No account required, no ID upload, no email needed for crypto. Accepts Monero, Bitcoin, and Lightning via self-hosted BTCPay Server.
 
 ## Point of Sale
 


### PR DESCRIPTION
## Add PikaSim to Merchants section

Adding PikaSim as a merchant that accepts Monero payments.

### About PikaSim

**URL:** https://pikasim.com

**Features:**
- Privacy-focused eSIM provider for 170+ countries
- No account required
- No ID upload needed
- No email required for crypto payments
- Accepts Monero, Bitcoin, and Lightning Network via self-hosted BTCPay Server
- Instant eSIM delivery

### Why it fits the Merchants section
PikaSim is a real merchant accepting Monero for a practical service (mobile data/eSIMs). It aligns with Monero's privacy principles - no KYC, no personal data collection, and true anonymity when paying with XMR.

Submitted by: codebruinc (pikasim.com)