### PR TITLE
Add xmrtousdc.xyz — Non-custodial XMR↔USDC swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ A curated list of awesome Monero libraries, tools, and resources. More focused o
 - [Bisq](https://github.com/bisq-network/bisq) ([Website](https://bisq.network/)) - A decentralized exchange network for trading Monero and other cryptocurrencies.
 - [Haveno](https://github.com/haveno-dex/haveno) - A decentralized, peer-to-peer, non-custodial Monero exchange for trading fiat currencies for Monero. This is only the software / protocol. Haveno can run in multiple networks / instances.
 - [RetoSwap](https://github.com/retoaccess1/haveno-reto) - The first public haveno network. 
+- [xmrtousdc](https://xmrtousdc.xyz) - Non-custodial XMR ↔ USDC swap service on Arbitrum. No KYC, no account required. [Telegram Bot](https://t.me/xmrtousdc_bot) | [API](https://xmrtousdc.xyz/openapi.json)
 - [Serai](https://github.com/serai-dex/serai) - Serai is a new DEX, built from the ground up, initially planning on listing Bitcoin, Ethereum, DAI, and Monero, offering a liquidity-pool-based trading experience. Funds are stored in an economically secured threshold-multisig wallet.
 - [BasicSwapDex](https://github.com/tecnovert/basicswap) ([Website](https://basicswapdex.com/)) - The BasicSwap DEX is a privacy-first and decentralized exchange which features cross-chain atomic swaps and a distributed order book.
 


### PR DESCRIPTION
Adding [xmrtousdc.xyz](https://xmrtousdc.xyz) to the Decentralized Exchanges section.

**What it does:** Non-custodial XMR ↔ USDC swaps on Arbitrum. No KYC, no account required.

**Why it fits:** Fills a gap for direct XMR→stablecoin conversion without intermediaries.

**Features:**
- Web interface
- Telegram bot ([@xmrtousdc_bot](https://t.me/xmrtousdc_bot))
- Open API ([OpenAPI spec](https://xmrtousdc.xyz/openapi.json))

Thanks for maintaining this list!