### PR TITLE
Add arnoldnakamura P2P XMR↔EUR trading service

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ A curated list of awesome Monero libraries, tools, and resources. More focused o
 - [XMRBazaar](https://xmrbazaar.com/) - P2P marketplace that accepts Monero. It is similar to MoneroMarket and Facebook Marketplace. Messenger for buyer/seller is included with PGP encryption. (still in beta)
 - [PikaSim](https://pikasim.com) - Privacy-focused eSIM provider for 170+ countries. No account required, no ID upload, no email needed for crypto. Accepts Monero, Bitcoin, and Lightning via self-hosted BTCPay Server.
 
+- [arnoldnakamura](https://arnoldnakamura.codeberg.page) - P2P XMR↔EUR trading, Cash by Mail (EU-wide) + Face-to-Face (SW Germany). 683+ completed trades (formerly chingchongfalung on LocalMonero/AgoraDesk).
 ## Point of Sale
 
 - [Kasisto](https://github.com/amiuhle/kasisto) - A Monero Point of Sale payment system 


### PR DESCRIPTION
## Add arnoldnakamura P2P XMR trading service

Adds arnoldnakamura, an experienced P2P XMR↔EUR trader to the Merchants section.

**Service details:**
- Cash by Mail: EU-wide
- Face-to-Face: SW Germany (Frankfurt, Stuttgart, Mannheim, Heidelberg, Karlsruhe, Freiburg, Strasbourg)
- 683+ completed trades (formerly chingchongfalung on LocalMonero/AgoraDesk, 100% feedback)
- Reputation proof: https://web.archive.org/web/20240421/https://agoradesk.com/user/chingchongfalung
- Website: https://arnoldnakamura.codeberg.page
- Contact: Telegram @arnoldnakamura