### PR TITLE
Add 0xEsim (no-KYC crypto eSIM) to Merchants

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ A curated list of awesome Monero libraries, tools, and resources. More focused o
 - [Monerica](https://github.com/monerica-project/monerica) ([Website](https://monerica.com/)) - A directory for a Monero circular economy
 - [XMRBazaar](https://xmrbazaar.com/) - P2P marketplace that accepts Monero. It is similar to MoneroMarket and Facebook Marketplace. Messenger for buyer/seller is included with PGP encryption. (still in beta)
 - [PikaSim](https://pikasim.com) - Privacy-focused eSIM provider for 170+ countries. No account required, no ID upload, no email needed for crypto. Accepts Monero, Bitcoin, and Lightning via self-hosted BTCPay Server.
+- [0xEsim](https://0xesim.io) - Privacy-focused no-KYC eSIM for 190+ countries. No account, no ID, no email required. Pay with Monero, USDT and other crypto.
 
 ## Point of Sale
 


### PR DESCRIPTION
Adds 0xEsim to the Merchants section.

0xEsim (https://0xesim.io) is a no-KYC eSIM store covering 190+ countries.
Monero (XMR) is a first-class payment option — pick a plan, pay in XMR, and
the eSIM QR is delivered by email within minutes of on-chain confirmation.
No account, no ID and no email are required.

This fits alongside existing Merchants entries (e.g. PikaSim). Description
is kept factual and non-promotional. Country coverage (190+) and Monero
support reflect the live site.

Disclosure: I'm affiliated with 0xEsim.